### PR TITLE
Use env to figure out where bash is installed

### DIFF
--- a/awmtt.sh
+++ b/awmtt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # awmtt: awesomewm testing tool
 # https://github.com/mikar/awmtt
 


### PR DESCRIPTION
On many systems (OpenBSD, FreeBSD, Linux distros using pkgsrc.. etc) `bash` isn't always going to be in `/bin`, this diff will make it work on these systems.